### PR TITLE
fix(npm-resolver): unhandled rejection in fetch

### DIFF
--- a/.changeset/little-dragons-wave.md
+++ b/.changeset/little-dragons-wave.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/error": patch
+"@pnpm/npm-resolver": patch
+---
+
+Fix: unhandled rejection in npm resolver when fetch fails

--- a/packages/error/src/index.ts
+++ b/packages/error/src/index.ts
@@ -18,7 +18,7 @@ export default class PnpmError extends Error {
   }
 }
 
-export interface FetchErrorResponse { status: number, statusText: string }
+export interface FetchErrorResponse { status: number | string, statusText: string }
 
 export interface FetchErrorRequest { url: string, authHeaderValue?: string }
 

--- a/packages/npm-resolver/src/fetch.ts
+++ b/packages/npm-resolver/src/fetch.ts
@@ -50,11 +50,21 @@ export default async function fromRegistry (
   const op = retry.operation(fetchOpts.retry)
   return new Promise((resolve, reject) =>
     op.attempt(async (attempt) => {
-      const response = await fetch(uri, {
-        authHeaderValue,
-        retry: fetchOpts.retry,
-        timeout: fetchOpts.timeout,
-      }) as RegistryResponse
+      let response: RegistryResponse
+      try {
+        response = await fetch(uri, {
+          authHeaderValue,
+          retry: fetchOpts.retry,
+          timeout: fetchOpts.timeout,
+        }) as RegistryResponse
+      } catch (error) {
+        console.log(error)
+        reject(new FetchError({
+          url: uri,
+          authHeaderValue: authHeaderValue,
+        }, { status: error.code, statusText: error.message }))
+        return
+      }
       if (response.status > 400) {
         const request = {
           authHeaderValue,


### PR DESCRIPTION
When fetch command fails for any reason  catch it and return FetchError to avoid Unhandled rejection

Fixes issue #3261.